### PR TITLE
Updates the brick rotation sim to support both a pinned & planar brick

### DIFF
--- a/examples/planar_gripper/contact_force_qp.h
+++ b/examples/planar_gripper/contact_force_qp.h
@@ -76,7 +76,7 @@ class InstantaneousContactForceQP {
    * @param weight_thetaddot_error The weight of the angular acceleration error
    * in the cost. This error is made up of a PD term and a FF term.
    * @param weight_f_Cb The weight of the contact force in the cost.
-   * @param mu The brick/floor coefficient of static friction (stiction).
+   * @param mu The brick/fingertip coefficient of static friction (stiction).
    * @param I_B The brick's rotational moment of inertia around its axis of
    * rotation.
    * @param mass_B The mass of the brick.
@@ -157,9 +157,9 @@ class InstantaneousContactForceQPController
    */
   InstantaneousContactForceQPController(
       BrickType brick_type, const multibody::MultibodyPlant<double>* plant,
-      const Eigen::Ref<const Eigen::Matrix2d>& Kp_tr,
-      const Eigen::Ref<const Eigen::Matrix2d>& Kd_tr, double Kp_ro,
-      double Kd_ro, double weight_a_error, double weight_thetaddot_error,
+      const Eigen::Ref<const Eigen::Matrix2d>& Kp_t,
+      const Eigen::Ref<const Eigen::Matrix2d>& Kd_t, double Kp_r,
+      double Kd_r, double weight_a_error, double weight_thetaddot_error,
       double weight_f_Cb_B, double mu, double translational_damping,
       double rotational_damping, double I_B, double mass_B);
 

--- a/examples/planar_gripper/finger_brick_control.h
+++ b/examples/planar_gripper/finger_brick_control.h
@@ -203,17 +203,20 @@ struct QPControlOptions {
   //  of kGripperLcmPeriod.
   double plan_dt{0.01};
 
-  double theta0_{0};  // initial rotation angle (rad)
-  double thetaf_{0};  // final rotation angle (rad)
+  double yf_{0};  // final y position (m).
+  double zf_{0};  // final z position (m).
+  double thetaf_{0};  // final rotation angle (rad).
 
-  double QP_Kp_ro_{0};                      // QP controller rotational Kp gain
-  double QP_Kd_ro_{0};                      // QP controller rotational Kd gain
-  double QP_weight_thetaddot_error_{0};     // thetaddot error weight
+  double QP_Kp_r_{0};  // rotational Kp gain.
+  double QP_Kd_r_{0};  // rotational Kd gain.
+  Eigen::Matrix2d QP_Kp_t_{Eigen::Matrix2d::Zero()};  // translational Kp gain.
+  Eigen::Matrix2d QP_Kd_t_{Eigen::Matrix2d::Zero()};  // translational Kd gain.
+  double QP_weight_thetaddot_error_{0};  // thetaddot error weight.
   double QP_weight_acceleration_error_{0};  // tran. acceleration error weight.
-  double QP_weight_f_Cb_B_{0};  // contact force magnitude penalty weight
-  double QP_mu_{0};             // QP mu value
+  double QP_weight_f_Cb_B_{0};  // contact force magnitude penalty weight.
+  double QP_mu_{0};  // coefficient of static friction between brick/fingertip.
 
-  bool brick_only_{false};  // only control brick (no finger)
+  bool brick_only_{false};  // only control brick (no finger).
   double viz_force_scale_{
       0};  // scale factor for visualizing spatial force arrow.
 

--- a/examples/planar_gripper/planar_gripper.h
+++ b/examples/planar_gripper/planar_gripper.h
@@ -131,6 +131,16 @@ class PlanarGripper : public systems::Diagram<double> {
       const std::map<std::string, double>& map_in,
       const int num_positions) const;
 
+  /// Creates a velocity vector (in MBP joint velocity index ordering)
+  /// from the named joints and values in `map_in`.
+  VectorX<double> MakeBrickVelocityVector(
+      const std::map<std::string, double>& map_in);
+
+  /// Utility function for creating position vectors.
+  VectorX<double> MakeVelocityVector(
+      const std::map<std::string, double>& map_in,
+      const int num_velocities) const;
+
   /// Convenience method for setting all of the joint angles of the brick.
   /// @p q must have size 3 (y, z, theta).
   // TODO(rcory) Implement the const Context version that sets State instead.

--- a/examples/planar_gripper/run_planar_gripper_qp_lcm_controller.cc
+++ b/examples/planar_gripper/run_planar_gripper_qp_lcm_controller.cc
@@ -96,10 +96,9 @@ void GetQPPlannerOptions(const PlanarGripper& planar_gripper,
 
   qpoptions->T_ = FLAGS_T;
   qpoptions->plan_dt = FLAGS_QP_plan_dt;
-  qpoptions->theta0_ = FLAGS_theta0;
   qpoptions->thetaf_ = FLAGS_thetaf;
-  qpoptions->QP_Kp_ro_ = FLAGS_QP_Kp_ro;
-  qpoptions->QP_Kd_ro_ = FLAGS_QP_Kd_ro;
+  qpoptions->QP_Kp_r_ = FLAGS_QP_Kp_ro;
+  qpoptions->QP_Kd_r_ = FLAGS_QP_Kd_ro;
   qpoptions->QP_weight_thetaddot_error_ = FLAGS_QP_weight_thetaddot_error;
   qpoptions->QP_weight_f_Cb_B_ = FLAGS_QP_weight_f_Cb_B;
   qpoptions->QP_mu_ = FLAGS_QP_mu;

--- a/examples/planar_gripper/run_planar_gripper_qp_udp_controller.cc
+++ b/examples/planar_gripper/run_planar_gripper_qp_udp_controller.cc
@@ -46,8 +46,8 @@ DEFINE_double(thetaf, M_PI_4, "final theta (rad)");
 DEFINE_double(T, 1.5, "time horizon (s)");
 DEFINE_double(QP_plan_dt, 0.002, "The QP planner's timestep.");
 
-DEFINE_double(QP_Kp_ro, 150, "QP controller rotational Kp gain");
-DEFINE_double(QP_Kd_ro, 50, "QP controller rotational Kd gain");
+DEFINE_double(QP_Kp_r, 150, "QP controller rotational Kp gain");
+DEFINE_double(QP_Kd_r, 50, "QP controller rotational Kd gain");
 DEFINE_double(QP_weight_thetaddot_error, 1, "thetaddot error weight.");
 DEFINE_double(QP_weight_f_Cb_B, 1, "Contact force magnitude penalty weight");
 DEFINE_double(QP_mu, 1.0, "QP mu"); /* MBP defaults to mu1 == mu2 == 1.0 */
@@ -102,10 +102,9 @@ void GetQPPlannerOptions(const PlanarGripper& planar_gripper,
 
   qpoptions->T_ = FLAGS_T;
   qpoptions->plan_dt = FLAGS_QP_plan_dt;
-  qpoptions->theta0_ = FLAGS_theta0;
   qpoptions->thetaf_ = FLAGS_thetaf;
-  qpoptions->QP_Kp_ro_ = FLAGS_QP_Kp_ro;
-  qpoptions->QP_Kd_ro_ = FLAGS_QP_Kd_ro;
+  qpoptions->QP_Kp_r_ = FLAGS_QP_Kp_r;
+  qpoptions->QP_Kd_r_ = FLAGS_QP_Kd_r;
   qpoptions->QP_weight_thetaddot_error_ = FLAGS_QP_weight_thetaddot_error;
   qpoptions->QP_weight_f_Cb_B_ = FLAGS_QP_weight_f_Cb_B;
   qpoptions->QP_mu_ = FLAGS_QP_mu;


### PR DESCRIPTION
- Updates the brick rotation sim to support both a pinned brick and a planar brick.
- Resolves item 1 in issue #16.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcory/drake/27)
<!-- Reviewable:end -->
