### PR TITLE
Removes boolean argument to zero_gravity() method in PlanarGripper class.

### DIFF
--- a/examples/planar_gripper/planar_gripper.cc
+++ b/examples/planar_gripper/planar_gripper.cc
@@ -269,14 +269,8 @@ void PlanarGripper::SetupPlant(std::string orientation,
   is_plant_finalized_ = true;
 
   // Set the gravity field.
-  if (zero_gravity_) {
-    plant_->mutable_gravity_field().set_gravity_vector(Vector3d::Zero());
-    control_plant_->mutable_gravity_field().set_gravity_vector(
-        Vector3d::Zero());
-  } else {
-    plant_->mutable_gravity_field().set_gravity_vector(gravity);
-    control_plant_->mutable_gravity_field().set_gravity_vector(gravity);
-  }
+  plant_->mutable_gravity_field().set_gravity_vector(gravity);
+  control_plant_->mutable_gravity_field().set_gravity_vector(gravity);
 }
 
 void PlanarGripper::Finalize() {

--- a/examples/planar_gripper/planar_gripper.h
+++ b/examples/planar_gripper/planar_gripper.h
@@ -222,13 +222,16 @@ class PlanarGripper : public systems::Diagram<double> {
 
   void set_X_WG(math::RigidTransformd X_WG) { X_WG_ = X_WG; }
 
-  // Zero gravity always?
-  void zero_gravity(bool value) {
+  // Zero gravity always.
+  void zero_gravity() {
     if (is_diagram_finalized_) {
       throw std::logic_error(
           "zero_gravity() must be called before Finalize().");
     }
-    zero_gravity_ = value;
+    // Set the gravity field to zero.
+    plant_->mutable_gravity_field().set_gravity_vector(Vector3d::Zero());
+    control_plant_->mutable_gravity_field().set_gravity_vector(
+        Vector3d::Zero());
   }
 
   ModelInstanceIndex get_brick_index() const { return brick_index_; }
@@ -285,7 +288,6 @@ class PlanarGripper : public systems::Diagram<double> {
   double brick_floor_penetration_{0};  // For the vertical case.
   double floor_coef_static_friction_{0};
   double floor_coef_kinetic_friction_{0};
-  bool zero_gravity_{false};
 
   // The planar gripper frame G's transform w.r.t. the world frame W.
   math::RigidTransformd X_WG_;

--- a/examples/planar_gripper/run_planar_gripper_qp_lcm_controller.cc
+++ b/examples/planar_gripper/run_planar_gripper_qp_lcm_controller.cc
@@ -118,7 +118,7 @@ int DoMain() {
 
   PlanarGripper planar_gripper;
   planar_gripper.SetupPinBrick("vertical");
-  planar_gripper.zero_gravity(true);
+  planar_gripper.zero_gravity();
   planar_gripper.Finalize();
 
   // Create a std::map to hold all input/output ports.

--- a/examples/planar_gripper/run_planar_gripper_qp_udp_controller.cc
+++ b/examples/planar_gripper/run_planar_gripper_qp_udp_controller.cc
@@ -122,7 +122,7 @@ int DoMain() {
 
   PlanarGripper planar_gripper;
   planar_gripper.SetupPinBrick("vertical");
-  planar_gripper.zero_gravity(true);
+  planar_gripper.zero_gravity();
   planar_gripper.Finalize();
 
   // Create a std::map to hold all input/output ports.

--- a/examples/planar_gripper/run_planar_gripper_rotate_simulation.cc
+++ b/examples/planar_gripper/run_planar_gripper_rotate_simulation.cc
@@ -270,7 +270,9 @@ int DoMain() {
   planar_gripper->set_floor_coef_kinetic_friction(
       FLAGS_floor_coef_kinetic_friction);
   planar_gripper->set_brick_floor_penetration(FLAGS_brick_floor_penetration);
-  planar_gripper->zero_gravity(FLAGS_zero_gravity);
+  if (FLAGS_zero_gravity) {
+    planar_gripper->zero_gravity();
+  }
 
   // Setup the 1-dof brick version of the plant.
   auto X_WG = math::RigidTransformd(

--- a/examples/planar_gripper/run_planar_gripper_simulation.cc
+++ b/examples/planar_gripper/run_planar_gripper_simulation.cc
@@ -74,7 +74,9 @@ int DoMain() {
   // Setup the planar brick version of the plant.
   planar_gripper->SetupPlanarBrick(FLAGS_orientation);
   planar_gripper->set_penetration_allowance(FLAGS_penetration_allowance);
-  planar_gripper->zero_gravity(FLAGS_zero_gravity);
+  if (FLAGS_zero_gravity) {
+    planar_gripper->zero_gravity();
+  }
 
   // Finalize and build the diagram.
   planar_gripper->Finalize();

--- a/examples/planar_gripper/test/brick_only_qp_simulation.cc
+++ b/examples/planar_gripper/test/brick_only_qp_simulation.cc
@@ -42,7 +42,7 @@ int DoMain() {
 
   auto planar_gripper =
       builder.AddSystem<PlanarGripper>(FLAGS_time_step, false);
-  planar_gripper->zero_gravity(true);
+  planar_gripper->zero_gravity();
   planar_gripper->set_brick_floor_penetration(0);
 
   BrickType brick_type;


### PR DESCRIPTION
Avoids a call ordering issue between `SetupPlant()` and `zero_gravity()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcory/drake/32)
<!-- Reviewable:end -->
